### PR TITLE
Fix: Correct SliceType __eq__ comparison logic

### DIFF
--- a/src/cuda/tile/_ir/type.py
+++ b/src/cuda/tile/_ir/type.py
@@ -72,7 +72,7 @@ class SliceType(Type):
         return "Slice"
 
     def __eq__(self, other: Type):
-        return isinstance(other, NoneType)
+        return isinstance(other, SliceType)
 
     def __hash__(self):
         return hash("SliceType")


### PR DESCRIPTION
This PR fixes an incorrect equality comparison in SliceType.

Previously:
    __eq__ used isinstance(other, NoneType)
This produced incorrect results for SliceType comparisons.

Now:
    __eq__ correctly checks isinstance(other, SliceType)

This resolves issue #8 
