### PR TITLE
Remove redundant tile size checks

### DIFF
--- a/samples/VectorAddition.py
+++ b/samples/VectorAddition.py
@@ -235,13 +235,6 @@ def vec_add(a: torch.Tensor, b: torch.Tensor, use_gather: bool = False) -> torch
         # (TILE_X * TILE_Y) around 1024 (a common block size limit for threads).
         TILE_X = max(1, 1024 // TILE_Y)
 
-        # Further adjustment to ensure TILE_X * TILE_Y is not excessively large
-        # if N (and thus TILE_Y) is small, or to prevent TILE_X from becoming zero.
-        if TILE_X * TILE_Y > 1024 and TILE_X > 1:
-            TILE_X = 1024 // TILE_Y
-            if TILE_X == 0:
-                TILE_X = 1  # Ensure TILE_X is at least 1
-
         # Calculate the 2D grid dimensions for launching the kernel.
         # `math.ceil(M / TILE_X)` blocks along rows, `math.ceil(N / TILE_Y)` blocks along columns.
         grid = (math.ceil(M / TILE_X), math.ceil(N / TILE_Y), 1)


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0 -->

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The block following TILE_X = max(1, 1024 // TILE_Y) seems unnecessary. Since integer division ensures (1024 // Y) * Y <= 1024 and max(1, ...) prevents TILE_X from being 0, the subsequent checks appear to be unreachable code that re-calculates the same value. Can we remove this simplification or am I missing something ? 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/cutile-python/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
