### PR TITLE
ci: add GPU test job using self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,14 +173,6 @@ jobs:
       - name: Run tests
         run: pytest --durations=10 --junitxml=test-results.xml -m "not benchmark" .
 
-      - name: Upload test results
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: test-results-py${{ matrix.python-version }}
-          path: test-results.xml
-          retention-days: 7
-
       - name: Report test results
         if: ${{ !cancelled() }}
         uses: dorny/test-reporter@v3
@@ -190,51 +182,13 @@ jobs:
           reporter: java-junit
           fail-on-error: false
 
-  benchmark:
-    name: Benchmark
-    needs: [images, build, test]
-    runs-on: [self-hosted, gpu]
-    timeout-minutes: 60
-    continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
-      checks: write
-    container:
-      image: ${{ needs.images.outputs.test_py310 }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options: --gpus all
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Mark workspace as safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Download wheel
-        uses: actions/download-artifact@v7
-        with:
-          name: wheel-py3.10-linux-x86_64
-          path: dist/
-
-      - name: Install wheel
-        run: pip install dist/*.whl
-
       - name: Run benchmarks
+        if: matrix.python-version == '3.10'
+        continue-on-error: true
         run: pytest --durations=10 --junitxml=benchmark-results.xml -m "benchmark" .
 
-      - name: Upload benchmark results
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: benchmark-results
-          path: benchmark-results.xml
-          retention-days: 7
-
       - name: Report benchmark results
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.python-version == '3.10' }}
         uses: dorny/test-reporter@v3
         with:
           name: Benchmark Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,14 @@ jobs:
           path: test-results.xml
           retention-days: 7
 
+      - name: Report test results
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Test Results (Python ${{ matrix.python-version }})
+          path: test-results.xml
+          reporter: java-junit
+
       - name: Fix workspace permissions
         if: always()
         run: sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   images:
     name: Define Base Images
@@ -95,6 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.10"
@@ -127,7 +132,12 @@ jobs:
     needs: [images, build]
     runs-on: [self-hosted, gpu]
     timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+      checks: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.10"
@@ -165,7 +175,7 @@ jobs:
             --junitxml=test-results.xml
 
       - name: Upload test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
           name: test-results-py${{ matrix.python-version }}
@@ -173,7 +183,7 @@ jobs:
           retention-days: 7
 
       - name: Report test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: dorny/test-reporter@v3
         with:
           name: Test Results (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
           name: Test Results (Python ${{ matrix.python-version }})
           path: test-results.xml
           reporter: java-junit
+          fail-on-error: false
 
   benchmark:
     name: Benchmark
@@ -239,3 +240,4 @@ jobs:
           name: Benchmark Results
           path: benchmark-results.xml
           reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Mark workspace as safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Download wheel
         uses: actions/download-artifact@v7
         with:
@@ -168,7 +171,7 @@ jobs:
         run: pip install dist/*.whl
 
       - name: Run tests
-        run: pytest --durations=10 --junitxml=test-results.xml .
+        run: pytest --durations=10 --junitxml=test-results.xml -m "not benchmark" .
 
       - name: Upload test results
         if: ${{ !cancelled() }}
@@ -184,4 +187,55 @@ jobs:
         with:
           name: Test Results (Python ${{ matrix.python-version }})
           path: test-results.xml
+          reporter: java-junit
+
+  benchmark:
+    name: Benchmark
+    needs: [images, build]
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 60
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+    container:
+      image: ${{ needs.images.outputs.test_py310 }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --gpus all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Mark workspace as safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download wheel
+        uses: actions/download-artifact@v7
+        with:
+          name: wheel-py3.10-linux-x86_64
+          path: dist/
+
+      - name: Install wheel
+        run: pip install dist/*.whl
+
+      - name: Run benchmarks
+        run: pytest --durations=10 --junitxml=benchmark-results.xml -m "benchmark" .
+
+      - name: Upload benchmark results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark-results
+          path: benchmark-results.xml
+          retention-days: 7
+
+      - name: Report benchmark results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@v3
+        with:
+          name: Benchmark Results
+          path: benchmark-results.xml
           reporter: java-junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       build_py311: ghcr.io/nvidia/cutile-python/build_py_3.11_x86_64:2026-03-18-8573f3996301
       build_py312: ghcr.io/nvidia/cutile-python/build_py_3.12_x86_64:2026-03-18-63835ff03f5d
       build_py313: ghcr.io/nvidia/cutile-python/build_py_3.13_x86_64:2026-03-18-9cadab6c475e
-      test_py310: ghcr.io/nvidia/cutile-python/test_py_3.10_x86_64:2026-03-18-09e8ff4f33de
-      test_py311: ghcr.io/nvidia/cutile-python/test_py_3.11_x86_64:2026-03-18-0f68d8d46ac4
-      test_py312: ghcr.io/nvidia/cutile-python/test_py_3.12_x86_64:2026-03-18-3fe476fda925
-      test_py313: ghcr.io/nvidia/cutile-python/test_py_3.13_x86_64:2026-03-18-f40db2451d39
+      test_py310: ghcr.io/nvidia/cutile-python/test_py_3.10_x86_64:2026-03-25-d688c40b1f28
+      test_py311: ghcr.io/nvidia/cutile-python/test_py_3.11_x86_64:2026-03-25-ee977c750e6a
+      test_py312: ghcr.io/nvidia/cutile-python/test_py_3.12_x86_64:2026-03-25-4a28b7ac9c10
+      test_py313: ghcr.io/nvidia/cutile-python/test_py_3.13_x86_64:2026-03-25-daa77b7df120
     steps:
       - run: echo "Defining image tags"
 
@@ -168,11 +168,7 @@ jobs:
         run: pip install dist/*.whl
 
       - name: Run tests
-        run: |
-          pytest --ignore internal \
-            -m 'not benchmark and not use_mlir' \
-            --durations=10 \
-            --junitxml=test-results.xml
+        run: pytest --durations=10 --junitxml=test-results.xml .
 
       - name: Upload test results
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    needs: [images, build]
+    needs: [images, build, test]
     runs-on: [self-hosted, gpu]
     timeout-minutes: 60
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
             image_key: test_py312
           - python-version: "3.13"
             image_key: test_py313
+    container:
+      image: ${{ needs.images.outputs[matrix.image_key] }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --gpus all
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -148,27 +154,15 @@ jobs:
           name: wheel-py${{ matrix.python-version }}-linux-x86_64
           path: dist/
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull test image
-        run: docker pull ${{ needs.images.outputs[matrix.image_key] }}
+      - name: Install wheel
+        run: pip install dist/*.whl
 
       - name: Run tests
         run: |
-          docker run --rm --gpus all \
-            -v "${{ github.workspace }}":/workspace \
-            -w /workspace \
-            ${{ needs.images.outputs[matrix.image_key] }} \
-            bash -c "pip install dist/*.whl && \
-              pytest --ignore internal \
-                -m 'not benchmark and not use_mlir' \
-                --durations=10 \
-                --junitxml=/workspace/test-results.xml"
+          pytest --ignore internal \
+            -m 'not benchmark and not use_mlir' \
+            --durations=10 \
+            --junitxml=test-results.xml
 
       - name: Upload test results
         if: always()
@@ -185,7 +179,3 @@ jobs:
           name: Test Results (Python ${{ matrix.python-version }})
           path: test-results.xml
           reporter: java-junit
-
-      - name: Fix workspace permissions
-        if: always()
-        run: sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,16 @@ jobs:
     name: Define Base Images
     runs-on: ubuntu-latest
     outputs:
-      lint: ghcr.io/nvidia/cutile-python/lint:2026-03-02-d33a8a50c68d
-      docs: ghcr.io/nvidia/cutile-python/docs:2026-03-02-2ab6fb9d9368
-      build_py310: ghcr.io/nvidia/cutile-python/build_py_3.10_x86_64:2026-03-02-c7f3f36001fd
-      build_py311: ghcr.io/nvidia/cutile-python/build_py_3.11_x86_64:2026-03-02-92c972404358
-      build_py312: ghcr.io/nvidia/cutile-python/build_py_3.12_x86_64:2026-03-02-299d123ad082
-      build_py313: ghcr.io/nvidia/cutile-python/build_py_3.13_x86_64:2026-03-02-8eea98e968b5
+      lint: ghcr.io/nvidia/cutile-python/lint:2026-03-18-3ee906b0ced0
+      docs: ghcr.io/nvidia/cutile-python/docs:2026-03-18-67c908a4176e
+      build_py310: ghcr.io/nvidia/cutile-python/build_py_3.10_x86_64:2026-03-18-a2fdea5320fe
+      build_py311: ghcr.io/nvidia/cutile-python/build_py_3.11_x86_64:2026-03-18-8573f3996301
+      build_py312: ghcr.io/nvidia/cutile-python/build_py_3.12_x86_64:2026-03-18-63835ff03f5d
+      build_py313: ghcr.io/nvidia/cutile-python/build_py_3.13_x86_64:2026-03-18-9cadab6c475e
+      test_py310: ghcr.io/nvidia/cutile-python/test_py_3.10_x86_64:2026-03-18-09e8ff4f33de
+      test_py311: ghcr.io/nvidia/cutile-python/test_py_3.11_x86_64:2026-03-18-0f68d8d46ac4
+      test_py312: ghcr.io/nvidia/cutile-python/test_py_3.12_x86_64:2026-03-18-3fe476fda925
+      test_py313: ghcr.io/nvidia/cutile-python/test_py_3.13_x86_64:2026-03-18-f40db2451d39
     steps:
       - run: echo "Defining image tags"
 
@@ -116,4 +120,60 @@ jobs:
           name: wheel-py${{ matrix.python-version }}-linux-x86_64
           path: dist/*.whl
           if-no-files-found: error
+          retention-days: 7
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    needs: [images, build]
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.10"
+            image_key: test_py310
+          - python-version: "3.11"
+            image_key: test_py311
+          - python-version: "3.12"
+            image_key: test_py312
+          - python-version: "3.13"
+            image_key: test_py313
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-py${{ matrix.python-version }}-linux-x86_64
+          path: dist/
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test image
+        run: docker pull ${{ needs.images.outputs[matrix.image_key] }}
+
+      - name: Run tests
+        run: |
+          docker run --rm --gpus all \
+            -v "${{ github.workspace }}":/workspace \
+            -w /workspace \
+            ${{ needs.images.outputs[matrix.image_key] }} \
+            bash -c "pip install dist/*.whl && \
+              pytest --ignore internal \
+                -m 'not benchmark and not use_mlir' \
+                --durations=10 \
+                --junitxml=/workspace/test-results.xml"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-py${{ matrix.python-version }}
+          path: test-results.xml
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,7 @@ jobs:
           name: test-results-py${{ matrix.python-version }}
           path: test-results.xml
           retention-days: 7
+
+      - name: Fix workspace permissions
+        if: always()
+        run: sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheel-py3.12-linux-x86_64
           path: dist/
@@ -83,7 +83,7 @@ jobs:
         run: make -C docs html
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs-html
           path: docs/build/html
@@ -115,7 +115,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-py${{ matrix.python-version }}-linux-x86_64
           path: dist/*.whl
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheel-py${{ matrix.python-version }}-linux-x86_64
           path: dist/
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-py${{ matrix.python-version }}
           path: test-results.xml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Report test results
         if: always()
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: Test Results (Python ${{ matrix.python-version }})
           path: test-results.xml


### PR DESCRIPTION
Add a test matrix job that runs on self-hosted GPU runners. Tests run inside Docker containers with `--gpus all` using the pre-built test images from GHCR. Also update all image tags to 2026-03-18 builds which include tileiras 13.2 (adds sm_86 support).

<!--- SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0 -->

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cutile-python/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
