### PR TITLE
Use cmake --build instead of make -C

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class BuildExtWithCmake(build_ext):
                         f"/p:Configuration={build_type}",
                         "/t:_cext"])
         else:
-            self.spawn(["make", "-C", build_dir, "-j", str(parallel)])
+            self.spawn(["cmake", "--build", build_dir, "-j", str(parallel)])
         # TODO: ideally, we should "make install" the library somewhere, so that CMake removes
         #   any build RPATHs etc. But I'll leave that for another day.
 


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0 -->

## Description

On my system, Ubuntu 24.04 image with CMake 3.28.3, the cmake config defaults to the ninja generator, leading to an error in `pip install -e .` because no `Makefile` is generated. Instead, we can use cmake to do the build as well using `cmake --build <build_dir>` which will call whatever tool matches the default generator.

Fixes #84 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cutile-python/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
