### PR TITLE
Fix CUDA loader format arguments

### DIFF
--- a/cext/cuda_loader.cpp
+++ b/cext/cuda_loader.cpp
@@ -21,14 +21,14 @@ void* do_get_proc_address(cuGetProcAddress_v2_t getter,
     if (res != CUDA_SUCCESS) {
         raise(PyExc_RuntimeError,
               "Failed to load '%s' from the CUDA library: cuGetProcAddress_v2 returned %d",
-              static_cast<int>(res));
+              name, static_cast<int>(res));
         return nullptr;
     }
 
     if (!ret) {
         raise(PyExc_RuntimeError,
               "Function '%s' is not available in the CUDA library",
-              static_cast<int>(res));
+              name);
         return nullptr;
     }
 


### PR DESCRIPTION
## Summary

- Pass the CUDA symbol name to the loader error message when `cuGetProcAddress_v2` fails.
- Pass the symbol name, not the CUDA result code, when a symbol resolves to a null function pointer.

## Why

These error paths use `%s` in `PyErr_Format`, but the old calls supplied an integer result code in that slot. If the loader hit either path, error reporting could interpret that integer as a string pointer instead of producing the intended exception.

## Validation

- `git diff --check`
- Full extension build not run locally: CUDA Toolkit / `nvcc` is not installed in this environment.
