### PR TITLE
setup.py: remove deprecated `dry_run` parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,7 @@ class BuildExtWithCmake(build_ext):
             ext_path = self.get_ext_fullpath(ext.name)
             # Create a symlink to the build directory if in editable mode, otherwise copy
             link = "sym" if self.editable_mode else None
-            file_util.copy_file(ext_build_path, ext_path, update=1, link=link,
-                                dry_run=self.dry_run)
+            file_util.copy_file(ext_build_path, ext_path, update=1, link=link,)
 
 
 def _get_csrc_dir(ext_name: str):


### PR DESCRIPTION
The `dry_run` parameter has been deprecated since setuptools v81.0.0: https://setuptools.pypa.io/en/latest/history.html#v81-0-0

<!--- SPDX-FileCopyrightText: Copyright (c) <2025> NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!--- SPDX-License-Identifier: Apache-2.0 -->

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/cutile-python/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
